### PR TITLE
Use the freebsd gethostid call

### DIFF
--- a/lib/libspl/gethostid.c
+++ b/lib/libspl/gethostid.c
@@ -29,6 +29,7 @@
 #include <sys/stat.h>
 #include <sys/systeminfo.h>
 
+#ifndef __FreeBSD__
 static unsigned long
 get_spl_hostid(void)
 {
@@ -56,10 +57,14 @@ get_spl_hostid(void)
 
 	return (hostid & HOSTID_MASK);
 }
+#endif
 
 unsigned long
 get_system_hostid(void)
 {
+#ifdef __FreeBSD__
+	unsigned long system_hostid = gethostid();
+#else
 	unsigned long system_hostid = get_spl_hostid();
 	/*
 	 * We do not use the library call gethostid() because
@@ -82,5 +87,7 @@ get_system_hostid(void)
 			close(fd);
 		}
 	}
+#endif
+
 	return (system_hostid);
 }


### PR DESCRIPTION
Use the freebsd gethostid call, otherwise the pool won't match the kernel.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://github.com/zfsonlinux/zfs/wiki/Buildbot-Options
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Pools created by ZoF cannot be imported by ZoF.

<!--- If it fixes an open issue, please link to the issue here. -->

### Description
<!--- Describe your changes in detail -->
For FreeBSD, use the native gethostid() call, as that uses the
same mechanism the kernel does.  Importing then works.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
zpool create tank ada0p2 ; zpool export tank ; zpool import tank

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).