### PR TITLE
fix -Werror=maybe-uninitialized error

### DIFF
--- a/lib/libzfs/freebsd_fsshare.c
+++ b/lib/libzfs/freebsd_fsshare.c
@@ -72,7 +72,7 @@ static char *
 zgetline(FILE *fd, const char *skip)
 {
 	static char line[MAXLINESIZE];
-	size_t len, skiplen;
+	size_t len, skiplen = 0;
 	char *s, last;
 
 	if (skip != NULL)


### PR DESCRIPTION



### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix -Werror=maybe-uninitialized error
```
    freebsd_fsshare.c: In function 'fsshare_main':
    freebsd_fsshare.c:90:8: error: 'skiplen' may be used uninitialized in this function [-Werror=maybe-uninitialized]
       last = line[skiplen];
       ~~~~~^~~~~~~~~~~~~~~
    freebsd_fsshare.c:75:14: note: 'skiplen' was declared here
      size_t len, skiplen;
                  ^~~~~~~
```

### Description
<!--- Describe your changes in detail -->
skiplen should be 0 when !skip.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
