### PR TITLE
Restore the name of vfs.zfs.compressed_arc_enabled

### DIFF
--- a/module/os/freebsd/zfs/freebsd_sysctl.c
+++ b/module/os/freebsd/zfs/freebsd_sysctl.c
@@ -106,7 +106,7 @@ SYSCTL_INT(_vfs_zfs, OID_AUTO, l2arc_feed_again, CTLFLAG_RW,
     &l2arc_feed_again, 0, "turbo warmup");
 SYSCTL_INT(_vfs_zfs, OID_AUTO, l2arc_norw, CTLFLAG_RW,
     &l2arc_norw, 0, "no reads during writes");
-SYSCTL_INT(_vfs_zfs, OID_AUTO, zfs_compressed_arc_enabled, CTLFLAG_RW,
+SYSCTL_INT(_vfs_zfs, OID_AUTO, compressed_arc_enabled, CTLFLAG_RW,
     &zfs_compressed_arc_enabled, 1, "compressed arc buffers");
 
 SYSCTL_UQUAD(_vfs_zfs, OID_AUTO, anon_size, CTLFLAG_RD,

--- a/tests/zfs-tests/tests/functional/fault/decompress_fault.ksh
+++ b/tests/zfs-tests/tests/functional/fault/decompress_fault.ksh
@@ -34,7 +34,7 @@ log_assert "Testing that injected decompression errors are handled correctly"
 function cleanup
 {
 	if is_freebsd; then
-		log_must set_tunable64 vfs.zfs.zfs_compressed_arc_enabled 1
+		log_must set_tunable64 vfs.zfs.compressed_arc_enabled 1
 	else
 		log_must set_tunable64 zfs_compressed_arc_enabled 1
 	fi
@@ -46,7 +46,7 @@ log_onexit cleanup
 
 default_mirror_setup_noexit $DISK1 $DISK2
 if is_freebsd; then
-	log_must set_tunable64 vfs.zfs.zfs_compressed_arc_enabled 0
+	log_must set_tunable64 vfs.zfs.compressed_arc_enabled 0
 else
 	log_must set_tunable64 zfs_compressed_arc_enabled 0
 fi


### PR DESCRIPTION
This fixes top(1) and other consumers of this sysctl, and restores compatibility with what this sysctl was called in FreeBSD