### PR TITLE
Zof zpoolcache bootfix

### DIFF
--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -820,7 +820,11 @@ typedef struct zpool_load_policy {
  * The location of the pool configuration repository, shared between kernel and
  * userland.
  */
+#ifdef __FreeBSD__
+#define	ZPOOL_CACHE		"/boot/zfs/zpool.cache"
+#else
 #define	ZPOOL_CACHE		"/etc/zfs/zpool.cache"
+#endif
 
 /*
  * vdev states are ordered from least to most healthy.

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -846,7 +846,7 @@ extern kmutex_t spa_namespace_lock;
 #define	SPA_CONFIG_UPDATE_VDEVS	1
 
 extern void spa_write_cachefile(spa_t *, boolean_t, boolean_t);
-extern void spa_config_load(void);
+extern void spa_config_load(boolean_t);
 extern nvlist_t *spa_all_configs(uint64_t *);
 extern void spa_config_set(spa_t *spa, nvlist_t *config);
 extern nvlist_t *spa_config_generate(spa_t *spa, vdev_t *vd, uint64_t txg,

--- a/module/os/freebsd/zfs/freebsd_kmod.c
+++ b/module/os/freebsd/zfs/freebsd_kmod.c
@@ -387,6 +387,11 @@ static moduledata_t zfs_mod = {
 	zfs_modevent,
 	0
 };
+
+#ifdef _KERNEL
+EVENTHANDLER_DEFINE(mountroot, spa_boot_init, NULL, 0);
+#endif
+
 DECLARE_MODULE(zfsctrl, zfs_mod, SI_SUB_CLOCKS, SI_ORDER_ANY);
 MODULE_VERSION(zfsctrl, 1);
 MODULE_DEPEND(zfsctrl, krpc, 1, 1, 1);

--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -74,7 +74,7 @@ int zfs_autoimport_disable = 1;
  * only populates the namespace.
  */
 void
-spa_config_load(void)
+spa_config_load(boolean_t boot)
 {
 	void *buf = NULL;
 	nvlist_t *nvlist, *child;
@@ -86,7 +86,7 @@ spa_config_load(void)
 	int err;
 
 #ifdef _KERNEL
-	if (zfs_autoimport_disable)
+	if (boot == B_FALSE && zfs_autoimport_disable)
 		return;
 #endif
 

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -2278,7 +2278,7 @@ spa_name_compare(const void *a1, const void *a2)
 void
 spa_boot_init(void)
 {
-	spa_config_load();
+	spa_config_load(B_TRUE);
 }
 
 void
@@ -2333,7 +2333,7 @@ spa_init(spa_mode_t mode)
 	zfs_prop_init();
 	zpool_prop_init();
 	zpool_feature_init();
-	spa_config_load();
+	spa_config_load(B_FALSE);
 	l2arc_start();
 	scan_init();
 	qat_init();


### PR DESCRIPTION
Fix the path to the cachefile to match what FreeBSD has always used

Restore the EVENTHANDLER for mountroot

and add a way to bypass automount_disable=1 during the boot case (it is useful to have it not auto import the pools when you kldload the module manually)