### PR TITLE
The GEOM attribute rotation_rate is a uint16_t

### DIFF
--- a/module/os/freebsd/zfs/vdev_geom.c
+++ b/module/os/freebsd/zfs/vdev_geom.c
@@ -767,7 +767,8 @@ vdev_geom_open(vdev_t *vd, uint64_t *psize, uint64_t *max_psize,
 {
 	struct g_provider *pp;
 	struct g_consumer *cp;
-	int error, has_trim, rate;
+	int error, has_trim;
+	uint16_t rate;
 
 	/*
 	 * Set the TLS to indicate downstack that we

--- a/module/os/freebsd/zfs/vdev_geom.c
+++ b/module/os/freebsd/zfs/vdev_geom.c
@@ -921,7 +921,11 @@ skip_open:
 	vd->vdev_nowritecache = B_FALSE;
 
 	/* Inform the ZIO pipeline that we are non-rotational */
-	vd->vdev_nonrot = (g_getattr("GEOM::rotation_rate", cp, &rate) == 0);
+        error = g_getattr("GEOM::rotation_rate", cp, &rate);
+        if (error == 0 && rate == 1)
+                vd->vdev_nonrot = B_TRUE;
+        else
+                vd->vdev_nonrot = B_FALSE;
 
 	/* Set when device reports it supports TRIM. */
 	error = g_getattr("GEOM::candelete", cp, &has_trim);


### PR DESCRIPTION
Results in the following error during boot:

g_handleattr: ada0 GEOM::rotation_rate bio_length 4 len 2 -> EFAULT

Signed-off-by: Allan Jude <allanjude@freebsd.org>
