### PR TITLE
Fix definition of BLKGETSIZE64 on FreeBSD

### DIFF
--- a/lib/libspl/include/os/freebsd/sys/mount.h
+++ b/lib/libspl/include/os/freebsd/sys/mount.h
@@ -35,12 +35,8 @@
 #include <string.h>
 #include <stdlib.h>
 
-/*
- * Some old glibc headers don't define BLKGETSIZE64
- * and we don't want to require the kernel headers
- */
 #if !defined(BLKGETSIZE64)
-#define	BLKGETSIZE64		_IOR(0x12, 114, size_t)
+#define	BLKGETSIZE64		DIOCGMEDIASIZE
 #endif
 
 /*


### PR DESCRIPTION
### Description
This looks like a copy-paste error, the matching FreeBSD ioctl is DIOCGMEDIASIZE.


### How Has This Been Tested?
Compiles. It's unlikely this code is used though since the broken definition didn't cause any issues before.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the ZFS on Linux [code style requirements](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [x] I have updated the documentation accordingly.
- [x] I have read the [**contributing** document](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/zfsonlinux/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [x] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/zfsonlinux/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
